### PR TITLE
Chore: Misc perf

### DIFF
--- a/packages/cart/src/app.js
+++ b/packages/cart/src/app.js
@@ -1,10 +1,9 @@
 import ReactDOM from "react-dom";
 import { html, Layout } from "webpack-mfe-shared";
-import CartPage from "./pages/cart";
 
 const App = (props) => html `<${Layout} ...${props} />`;
 
 ReactDOM.render(
-  html `<${App} app="Cart" pages=${{ CartPage }} />`,
+  html `<${App} app="Cart" />`,
   document.getElementById("root")
 );

--- a/packages/cart/src/pages/cart.js
+++ b/packages/cart/src/pages/cart.js
@@ -47,7 +47,9 @@ const CartPage = () => html `
         </tr>
         <tr key="cart-checkout" style=${{ borderTop: "1px solid #cbcbcb" }}>
           <td colSpan="4" style=${{ textAlign: "center" }}>
-            <${CheckoutButton} />
+            <${React.Suspense} fallback=${null}>
+              <${CheckoutButton} />
+            </${React.Suspense}>
           </td>
         </tr>
       </tbody>

--- a/packages/cart/src/pages/cart.js
+++ b/packages/cart/src/pages/cart.js
@@ -58,10 +58,4 @@ const CartPage = () => html `
   </${Page}>
 `;
 
-const LazyCartPage = (props) => html `
-  <${React.Suspense} fallback=${null}>
-    <${CartPage} ...${props} />
-  </${React.Suspense}>
-`;
-
-export default LazyCartPage;
+export default CartPage;

--- a/packages/checkout/src/app.js
+++ b/packages/checkout/src/app.js
@@ -1,11 +1,9 @@
 import ReactDOM from "react-dom";
 import { html, Layout } from "webpack-mfe-shared";
-import CheckoutPage from "./pages/checkout";
-import ThankYouPage from "./pages/thank-you";
 
 const App = (props) => html `<${Layout} ...${props} />`;
 
 ReactDOM.render(
-  html `<${App} app="Checkout" pages=${{ CheckoutPage, ThankYouPage }} />`,
+  html `<${App} app="Checkout" />`,
   document.getElementById("root")
 );

--- a/packages/homepage/src/app.js
+++ b/packages/homepage/src/app.js
@@ -1,12 +1,9 @@
 import ReactDOM from "react-dom";
 import { html, Layout } from "webpack-mfe-shared";
-import Homepage from "./pages/homepage";
 
 const App = (props) => html `<${Layout} ...${props} />`;
 
-// **Note**: For shared page components that _our_ application has, pass them
-// directly for speed of inclusion.
 ReactDOM.render(
-  html `<${App} app="Home" pages=${{ Homepage }} />`,
+  html `<${App} app="Home" />`,
   document.getElementById("root")
 );

--- a/packages/homepage/src/pages/homepage.js
+++ b/packages/homepage/src/pages/homepage.js
@@ -30,7 +30,11 @@ const Homepage = () => {
         <p style=${{ fontSize: "1.5em", lineHeight: "2em" }}>
           Welcome to the emoji store!
         </p>
-        ${items.map((props) => html `<${Item} ...${props} key="home-item-${props.id}" />`)}
+        ${items.map((props) => html `
+          <${React.Suspense} fallback=${null} key="home-item-${props.id}">
+            <${Item} ...${props} />
+          </${React.Suspense}>
+        `)}
       </div>
     </${Page}>
   `;

--- a/packages/item/src/app.js
+++ b/packages/item/src/app.js
@@ -1,11 +1,9 @@
 import ReactDOM from "react-dom";
 import { html, Layout } from "webpack-mfe-shared";
-import ItemsPage from "./pages/items";
-import ItemPage from "./pages/item";
 
 const App = (props) => html `<${Layout} ...${props} />`;
 
 ReactDOM.render(
-  html `<${App} app="Item" pages=${{ ItemsPage, ItemPage }} />`,
+  html `<${App} app="Item" />`,
   document.getElementById("root")
 );

--- a/packages/item/src/components/item.js
+++ b/packages/item/src/components/item.js
@@ -10,11 +10,8 @@ const AddToCart = React.lazy(eagerImport(() => import("app_cart/components/add-t
 // ----------------------------------------------------------------------------
 // Components
 // ----------------------------------------------------------------------------
-const Loading = ({ id }) => html `
-  <div style=${{ textAlign: "center" }} className="pure-u-1-3">
-    <em style=${{ fontSize: "1.5em", lineHeight: "2em" }}>Loading item ${id}...</em>
-  </div>
-`;
+// Keep position with same colored period.
+const EMPTY = html `<span style=${{ color: "#eeeeee" }} >.</span>`;
 
 const Item = ({ id, name, emoji }) => {
   const idNum = parseInt(id, 10);
@@ -32,11 +29,6 @@ const Item = ({ id, name, emoji }) => {
       .catch(() => {});
   }, [item, location]);
 
-  // Wait for data load.
-  if (!item.name || item.id !== idNum) {
-    return html `<${Loading} id=${id} />`;
-  }
-
   return html `
     <div
       className="pure-u-1-3"
@@ -46,8 +38,8 @@ const Item = ({ id, name, emoji }) => {
         to=${{ pathname: `/item/${item.id}`, state: { item } }}
         style=${{ color: "inherit", textDecoration: "none" }}
       >
-        <p style=${{ fontSize: "10em" }}>${item.emoji}</p>
-        <p style=${{ fontSize: "2em" }}>${item.name}</p>
+        <p style=${{ fontSize: "10em" }}>${item.emoji || EMPTY}</p>
+        <p style=${{ fontSize: "2em" }}>${item.name || EMPTY}</p>
       </${Link}>
       <${AddToCart} />
     </div>

--- a/packages/item/src/components/item.js
+++ b/packages/item/src/components/item.js
@@ -41,7 +41,9 @@ const Item = ({ id, name, emoji }) => {
         <p style=${{ fontSize: "10em" }}>${item.emoji || EMPTY}</p>
         <p style=${{ fontSize: "2em" }}>${item.name || EMPTY}</p>
       </${Link}>
-      <${AddToCart} />
+      <${React.Suspense} fallback=${null}>
+        <${AddToCart} />
+      </${React.Suspense}>
     </div>
   `;
 };

--- a/packages/item/src/pages/item.js
+++ b/packages/item/src/pages/item.js
@@ -1,9 +1,12 @@
 import Item from "../components/item";
 import { html, Page } from "webpack-mfe-shared";
 
+// Default: weary cat face
+const DEFAULT_ID = 102;
+
 const ItemPage = ({ location, match }) => {
   const item = ((location || {}).state || {}).item;
-  const id = ((match || {}).params || {}).id;
+  const id = ((match || {}).params || {}).id || DEFAULT_ID;
 
   return html `
     <${Page} name="Item">

--- a/packages/shared/src/components/layout.js
+++ b/packages/shared/src/components/layout.js
@@ -52,14 +52,26 @@ const PAGE_IMPORTS = {
 // Since apps provide their own page components, lazily (+ eagerly) populate
 // a global cache of pages to use.
 const PAGE_CACHE = Object.fromEntries(Object.keys(PAGE_IMPORTS).map((name) => [name, null]));
+let PAGE_CACHE_FILLED = false;
+
+const suspenseWrapper = (Component) => (props) => html `
+  <${React.Suspense} fallback=${null}>
+    <${Component} ...${props} />
+  </${React.Suspense}>
+`;
 
 const getPages = (pages) => {
+  if (PAGE_CACHE_FILLED) { return PAGE_CACHE; }
+
   Object.keys(PAGE_CACHE).forEach((name) => {
     if (!PAGE_CACHE[name]) {
-      PAGE_CACHE[name] = pages[name] || React.lazy(eagerImport(PAGE_IMPORTS[name]));
+      PAGE_CACHE[name] = suspenseWrapper(
+        pages[name] || React.lazy(eagerImport(PAGE_IMPORTS[name]))
+      );
     }
   });
 
+  PAGE_CACHE_FILLED = true;
   return PAGE_CACHE;
 };
 
@@ -88,14 +100,12 @@ const Layout = React.memo(({ app, pages = {} }) => {
           apps=${APP_LINKS}
         />
         <${Switch}>
-          <${React.Suspense} fallback=${null}>
-            <${Route} exact=${true} path="/" component=${Homepage} />
-            <${Route} exact=${true} path="/item/" component=${ItemsPage} />
-            <${Route} exact=${true} path="/item/:id" component=${ItemPage} />
-            <${Route} exact=${true} path="/cart" component=${CartPage} />
-            <${Route} exact=${true} path="/checkout" component=${CheckoutPage} />
-            <${Route} exact=${true} path="/checkout/thank-you" component=${ThankYouPage} />
-          </${React.Suspense}>
+          <${Route} exact=${true} path="/" component=${Homepage} />
+          <${Route} exact=${true} path="/item/" component=${ItemsPage} />
+          <${Route} exact=${true} path="/item/:id" component=${ItemPage} />
+          <${Route} exact=${true} path="/cart" component=${CartPage} />
+          <${Route} exact=${true} path="/checkout" component=${CheckoutPage} />
+          <${Route} exact=${true} path="/checkout/thank-you" component=${ThankYouPage} />
         </${Switch}>
       </${Router}>
     </div>

--- a/packages/shared/src/components/layout.js
+++ b/packages/shared/src/components/layout.js
@@ -79,7 +79,7 @@ const Layout = React.memo(({ app, pages = {} }) => {
   } = getPages(pages);
 
   return html `
-    <div id="layout">
+    <div id="layout" key="layout" >
       <${Router}>
         <${Menu}
           app="${app}${location.port ? ` (${location.port})` : ""}"
@@ -95,6 +95,9 @@ const Layout = React.memo(({ app, pages = {} }) => {
           <${Route} exact=${true} path="/checkout/thank-you" component=${ThankYouPage} />
         </${Switch}>
       </${Router}>
+    </div>
+    <!-- TODO: TRY AND REMOVE -- <Homepage /> -->
+    <div id="preload" key="preload" hidden={true}>
     </div>
   `;
 });

--- a/packages/shared/src/components/layout.js
+++ b/packages/shared/src/components/layout.js
@@ -96,11 +96,13 @@ const Layout = React.memo(({ app, pages = {} }) => {
           <${Route} exact=${true} path="/checkout/thank-you" component=${ThankYouPage} />
         </${Switch}>
         <!-- HACK: Do one default render of all components to avoid jank. -->
-        <div id="preload" key="preload" hidden=${true}>
-          ${Object.keys(PAGE_IMPORTS).map((name) =>
+        <${React.Suspense} fallback={null}>
+          <div id="preload" key="preload" hidden=${true}>
+            ${Object.keys(PAGE_IMPORTS).map((name) =>
     html `<${allPages[name]} key="preload-${name}" />`
   )}
-        </div>
+          </div>
+        </${React.Suspense}>
       </${Router}>
     </div>
 

--- a/packages/shared/src/components/layout.js
+++ b/packages/shared/src/components/layout.js
@@ -66,7 +66,7 @@ const getPages = (pages) => {
 // ----------------------------------------------------------------------------
 // Component
 // ----------------------------------------------------------------------------
-const Layout = ({ app, pages = {} }) => {
+const Layout = React.memo(({ app, pages = {} }) => {
   // Lazy imports, using provided pages directly first.
   // Each app container is responsible for injecting direct pages.
   const {
@@ -97,7 +97,7 @@ const Layout = ({ app, pages = {} }) => {
       </${Router}>
     </div>
   `;
-};
+});
 
 const LazyLayout = (props) => html `
   <${React.Suspense} fallback=${null}>

--- a/packages/shared/src/components/layout.js
+++ b/packages/shared/src/components/layout.js
@@ -98,12 +98,14 @@ const Layout = React.memo(({ app, pages = {} }) => {
           apps=${APP_LINKS}
         />
         <${Switch}>
-          <${Route} exact=${true} path="/" component=${Homepage} />
-          <${Route} exact=${true} path="/item/" component=${ItemsPage} />
-          <${Route} exact=${true} path="/item/:id" component=${ItemPage} />
-          <${Route} exact=${true} path="/cart" component=${CartPage} />
-          <${Route} exact=${true} path="/checkout" component=${CheckoutPage} />
-          <${Route} exact=${true} path="/checkout/thank-you" component=${ThankYouPage} />
+          <${React.Suspense} fallback=${null}>
+            <${Route} exact=${true} path="/" component=${Homepage} />
+            <${Route} exact=${true} path="/item/" component=${ItemsPage} />
+            <${Route} exact=${true} path="/item/:id" component=${ItemPage} />
+            <${Route} exact=${true} path="/cart" component=${CartPage} />
+            <${Route} exact=${true} path="/checkout" component=${CheckoutPage} />
+            <${Route} exact=${true} path="/checkout/thank-you" component=${ThankYouPage} />
+          </${React.Suspense}>
         </${Switch}>
         <${Preload} pages=${allPages} />
       </${Router}>
@@ -112,10 +114,4 @@ const Layout = React.memo(({ app, pages = {} }) => {
   `;
 });
 
-const LazyLayout = (props) => html `
-  <${React.Suspense} fallback=${null}>
-    <${Layout} ...${props} />
-  </${React.Suspense}>
-`;
-
-export default LazyLayout;
+export default Layout;

--- a/packages/shared/src/components/layout.js
+++ b/packages/shared/src/components/layout.js
@@ -96,7 +96,7 @@ const Layout = React.memo(({ app, pages = {} }) => {
           <${Route} exact=${true} path="/checkout/thank-you" component=${ThankYouPage} />
         </${Switch}>
         <!-- HACK: Do one default render of all components to avoid jank. -->
-        <${React.Suspense} fallback={null}>
+        <${React.Suspense} fallback=${null}>
           <div id="preload" key="preload" hidden=${true}>
             ${Object.keys(PAGE_IMPORTS).map((name) =>
     html `<${allPages[name]} key="preload-${name}" />`

--- a/packages/shared/src/components/layout.js
+++ b/packages/shared/src/components/layout.js
@@ -69,6 +69,7 @@ const getPages = (pages) => {
 const Layout = React.memo(({ app, pages = {} }) => {
   // Lazy imports, using provided pages directly first.
   // Each app container is responsible for injecting direct pages.
+  const allPages = getPages(pages);
   const {
     Homepage,
     ItemsPage,
@@ -76,7 +77,7 @@ const Layout = React.memo(({ app, pages = {} }) => {
     CartPage,
     CheckoutPage,
     ThankYouPage
-  } = getPages(pages);
+  } = allPages;
 
   return html `
     <div id="layout" key="layout" >
@@ -94,11 +95,15 @@ const Layout = React.memo(({ app, pages = {} }) => {
           <${Route} exact=${true} path="/checkout" component=${CheckoutPage} />
           <${Route} exact=${true} path="/checkout/thank-you" component=${ThankYouPage} />
         </${Switch}>
+        <!-- HACK: Do one default render of all components to avoid jank. -->
+        <div id="preload" key="preload" hidden=${true}>
+          ${Object.keys(PAGE_IMPORTS).map((name) =>
+    html `<${allPages[name]} key="preload-${name}" />`
+  )}
+        </div>
       </${Router}>
     </div>
-    <!-- TODO: TRY AND REMOVE -- <Homepage /> -->
-    <div id="preload" key="preload" hidden={true}>
-    </div>
+
   `;
 });
 

--- a/packages/shared/src/components/layout.js
+++ b/packages/shared/src/components/layout.js
@@ -63,6 +63,15 @@ const getPages = (pages) => {
   return PAGE_CACHE;
 };
 
+// HACK: Lazily preload all the base pages for faster transitions.
+const Preload = ({ pages }) => html `
+  <${React.Suspense} fallback=${null}>
+    <div id="preload" key="preload" hidden=${true}>
+      ${Object.entries(pages).map(([name, Comp]) => html `<${Comp} key="preload-${name}" />`)}
+    </div>
+  </${React.Suspense}>
+`;
+
 // ----------------------------------------------------------------------------
 // Component
 // ----------------------------------------------------------------------------
@@ -95,14 +104,7 @@ const Layout = React.memo(({ app, pages = {} }) => {
           <${Route} exact=${true} path="/checkout" component=${CheckoutPage} />
           <${Route} exact=${true} path="/checkout/thank-you" component=${ThankYouPage} />
         </${Switch}>
-        <!-- HACK: Do one default render of all components to avoid jank. -->
-        <${React.Suspense} fallback=${null}>
-          <div id="preload" key="preload" hidden=${true}>
-            ${Object.keys(PAGE_IMPORTS).map((name) =>
-    html `<${allPages[name]} key="preload-${name}" />`
-  )}
-          </div>
-        </${React.Suspense}>
+        <${Preload} pages=${allPages} />
       </${Router}>
     </div>
 

--- a/packages/shared/src/components/layout.js
+++ b/packages/shared/src/components/layout.js
@@ -64,6 +64,7 @@ const getPages = (pages) => {
 };
 
 // HACK: Lazily preload all the base pages for faster transitions.
+// See: https://medium.com/hackernoon/lazy-loading-and-preloading-components-in-react-16-6-804de091c82d
 const Preload = ({ pages }) => html `
   <${React.Suspense} fallback=${null}>
     <div id="preload" key="preload" hidden=${true}>

--- a/packages/shared/src/components/layout.js
+++ b/packages/shared/src/components/layout.js
@@ -63,16 +63,6 @@ const getPages = (pages) => {
   return PAGE_CACHE;
 };
 
-// HACK: Lazily preload all the base pages for faster transitions.
-// See: https://medium.com/hackernoon/lazy-loading-and-preloading-components-in-react-16-6-804de091c82d
-const Preload = ({ pages }) => html `
-  <${React.Suspense} fallback=${null}>
-    <div id="preload" key="preload" hidden=${true}>
-      ${Object.entries(pages).map(([name, Comp]) => html `<${Comp} key="preload-${name}" />`)}
-    </div>
-  </${React.Suspense}>
-`;
-
 // ----------------------------------------------------------------------------
 // Component
 // ----------------------------------------------------------------------------
@@ -107,7 +97,6 @@ const Layout = React.memo(({ app, pages = {} }) => {
             <${Route} exact=${true} path="/checkout/thank-you" component=${ThankYouPage} />
           </${React.Suspense}>
         </${Switch}>
-        <${Preload} pages=${allPages} />
       </${Router}>
     </div>
 

--- a/packages/shared/src/components/menu.js
+++ b/packages/shared/src/components/menu.js
@@ -10,7 +10,7 @@ export const MenuHeader = ({ name, to }) => html `
   <${Link} className="pure-menu-heading" to="${to}">${name}</${Link}>
 `;
 
-export const MenuPage = ({ name, to }) => {
+export const MenuPage = React.memo(({ name, to }) => {
   const location = useLocation();
   const [active, setActive] = React.useState(false);
   React.useEffect(() => {
@@ -24,9 +24,9 @@ export const MenuPage = ({ name, to }) => {
       </${NavLink}>
     </li>
   `;
-};
+});
 
-export const MenuApp = ({ name, href }) => {
+export const MenuApp = React.memo(({ name, href }) => {
   // Add port if number specified
   const port = (/:[0-9]+$/).test(href) ? ` (${href.split(":").pop()})` : "";
   const active = href.startsWith(location.origin);
@@ -37,9 +37,9 @@ export const MenuApp = ({ name, href }) => {
       </a>
     </li>
   `;
-};
+});
 
-export const Menu = ({ app, pages = [], apps = [] }) => html `
+export const Menu = React.memo(({ app, pages = [], apps = [] }) => html `
   <div id="menu">
     <nav className="pure-menu">
       <${MenuHeader} name="${app}" to="/" />
@@ -52,4 +52,4 @@ export const Menu = ({ app, pages = [], apps = [] }) => html `
       <div className="pure-menu-divided" />
     </nav>
   </div>
-`;
+`);

--- a/packages/shared/src/components/menu.js
+++ b/packages/shared/src/components/menu.js
@@ -3,7 +3,7 @@
  */
 
 import React from "react";
-import { Link, NavLink, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { html } from "../index";
 
 export const MenuHeader = ({ name, to }) => html `
@@ -19,9 +19,9 @@ export const MenuPage = React.memo(({ name, to }) => {
 
   return html `
     <li className="pure-menu-item${active ? " pure-menu-selected" : ""}">
-      <${NavLink} className="pure-menu-link" to="${to}">
+      <${Link} className="pure-menu-link" to="${to}">
         ${name}
-      </${NavLink}>
+      </${Link}>
     </li>
   `;
 });

--- a/packages/shared/src/components/page.js
+++ b/packages/shared/src/components/page.js
@@ -1,6 +1,7 @@
+import React from "react";
 import { html } from "webpack-mfe-shared";
 
-const Page = ({ name, children }) => html `
+const Page = React.memo(({ name, children }) => html `
   <div id="main">
     <div className="header">
       <h1>${name}</h1>
@@ -9,6 +10,6 @@ const Page = ({ name, children }) => html `
       ${children}
     </div>
   </div>
-`;
+`);
 
 export default Page;

--- a/packages/shared/src/data/index.js
+++ b/packages/shared/src/data/index.js
@@ -3,7 +3,6 @@
  *
  * Uses: https://github.com/abourtnik/emojis-world
  */
-// TODO: Memoize data fetch?
 
 const _fetchEmoji = ({ query }) => fetch(`https://api.emojisworld.io/v1/${query}`)
   .then((response) => response.json())

--- a/packages/shared/src/data/index.js
+++ b/packages/shared/src/data/index.js
@@ -13,16 +13,28 @@ const _fetchEmoji = ({ query }) => fetch(`https://api.emojisworld.io/v1/${query}
     return null;
   });
 
-export const fetchItem = ({ id }) => _fetchEmoji({ query: `emojis/${id}` })
-  .then((data = {}) => {
-    if (data.totals !== 1) {
-      // eslint-disable-next-line no-console
-      console.error(`Bad data for ${id}: ${JSON.stringify(data)}`);
-      return null;
-    }
+const _fetchItemCache = {};
 
-    return data.results[0];
-  });
+export const fetchItem = ({ id, cache = true }) => {
+  if (cache && _fetchItemCache[id]) {
+    return Promise.resolve(_fetchItemCache[id]);
+  }
+
+  return _fetchEmoji({ query: `emojis/${id}` })
+    .then((data = {}) => {
+      if (data.totals !== 1) {
+        // eslint-disable-next-line no-console
+        console.error(`Bad data for ${id}: ${JSON.stringify(data)}`);
+        return null;
+      }
+
+      if (cache) {
+        _fetchItemCache[id] = data.results[0];
+      }
+
+      return data.results[0];
+    });
+};
 
 export const fetchRandomItems = () => _fetchEmoji({ query: "random?limit=9" })
   .then((data) => data.results);


### PR DESCRIPTION
## Work
- Use React.memo to avoid unnecessary renders
- Make React.Suspense wrappers more narrow.
- Cache `fetchItem`
- Modify item component load to be same size
- Remove per-app component page passing (just use all lazy).

## Compare
- Previous: https://emojistore-staging-5-homepage.surge.sh/item
- New: https://emojistore-staging-7-homepage.surge.sh/item